### PR TITLE
Add --no-provision option to the Up command.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 # Gems required for testing only. To install run
 # gem bundle test
 group :test do
+  gem "rake"
   gem "contest", ">= 0.1.2"
   gem "mocha"
   gem "ruby-debug", ">= 0.10.3" if RUBY_VERSION < '1.9'

--- a/lib/tenderloin/actions/base.rb
+++ b/lib/tenderloin/actions/base.rb
@@ -24,7 +24,8 @@ module Tenderloin
     # documentation below.
     class Base
       # The {Runner runner} which is executing the action
-      attr_reader :runner
+      # The {Array arguments} which are passed when executing the action
+      attr_reader :runner, :run_args
 
       # Included so subclasses don't need to include it themselves.
       include Tenderloin::Util
@@ -33,7 +34,8 @@ module Tenderloin
       # been given to the {Runner runner}. This method can be used by subclasses
       # to save any of the configuration options which are passed in.
       def initialize(runner, *args)
-        @runner = runner
+        @runner   = runner
+        @run_args = args
       end
 
       # This method is called once per action, allowing the action

--- a/lib/tenderloin/actions/vm/up.rb
+++ b/lib/tenderloin/actions/vm/up.rb
@@ -18,7 +18,7 @@ msg
           # of other actions in its place:
           Tenderloin::Box.add(Tenderloin.config.vm.box, Tenderloin.config.vm.box_url) unless Tenderloin::Env.box
           steps = [Import, SharedFolders, Boot]
-          steps << Provision if Tenderloin.config.provisioning.enabled
+          steps << Provision if provision_enabled?
           steps.insert(0, MoveHardDrive) if Tenderloin.config.vm.hd_location
 
           steps.each do |action_klass|
@@ -50,6 +50,10 @@ msg
             data.delete 'displayname'
             data['displayName'] = "tenderloin-" + @runner.vm_id
           end
+        end
+
+        def provision_enabled?
+          Tenderloin.config.provisioning.enabled && !run_args.include?(:no_provision)
         end
       end
     end

--- a/lib/tenderloin/cli.rb
+++ b/lib/tenderloin/cli.rb
@@ -12,10 +12,16 @@ module Tenderloin
       end
     end
 
-    desc "up [--file <tenderfile>]", "Boots the VM"
+    desc "up [--file <tenderfile> --no-provision]", "Boots the VM"
+    method_option :provision, :default => true
     def up()
       setup
-      Tenderloin::Commands.up
+
+      if !options[:provision]
+        Tenderloin::Commands.up(:no_provision)
+      else
+        Tenderloin::Commands.up
+      end
     end
 
     desc "halt [--file <tenderfile>]", "Force shuts down the running VM"

--- a/lib/tenderloin/commands.rb
+++ b/lib/tenderloin/commands.rb
@@ -28,7 +28,7 @@ error
       # the base VM, setting up shared folders, forwarded ports, etc to
       # provisioning the instance with chef. {up} also starts the instance,
       # running it in the background.
-      def up
+      def up(provision = nil)
         Env.load!
 
         if Env.persisted_vm
@@ -36,7 +36,7 @@ error
           Env.persisted_vm.start
         else
           Env.require_box
-          VM.execute!(Actions::VM::Up)
+          VM.execute!(Actions::VM::Up, provision)
         end
       end
 

--- a/test/tenderloin/actions/vm/up_test.rb
+++ b/test/tenderloin/actions/vm/up_test.rb
@@ -95,4 +95,16 @@ class UpActionTest < Test::Unit::TestCase
       @action.setup_mac_address
     end
   end
+
+  context "booting without provisioning" do
+    should "not add the provision task to the expected sequence" do
+      mock_vm, vm, action = mock_action(Tenderloin::Actions::VM::Up, :no_provision)
+
+      mock_config do |config|
+        config.chef.enabled = true
+      end
+
+      action.should_not be_provision_enabled
+    end
+  end
 end


### PR DESCRIPTION
This way we can call provision on demand instead of forcing it.
